### PR TITLE
feat(): default latex capture

### DIFF
--- a/debug/wokespace-1/README.md
+++ b/debug/wokespace-1/README.md
@@ -1,0 +1,10 @@
+Multiple line formulas:
+
+```latex
+ \begin{eqnarray*}
+  \sum_{i=1}^{n} i^2 &=& \frac{n(n+1)(2n+1)}{6} \\
+  \sum_{i=1}^{n} i^3 &=& \left(\frac{n(n+1)}{2}\right)^2 \\
+  \sum_{i=1}^{n} i^4 &=& \frac{n(n+1)(2n+1)(3n^2 + 3n - 1)}{30} \\
+  \end{eqnarray*}
+
+```

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
             "c",
             "cpp",
             "matlab",
-            "python"
+            "python",
+            "markdown"
           ],
           "markdownDescription": "Enable extension in these [languages id](https://code.visualstudio.com/docs/languages/identifiers)."
         },

--- a/src/store/constant.ts
+++ b/src/store/constant.ts
@@ -24,4 +24,11 @@ export const CHARACTERS_NEED_ESCAPING = new Set([
 export const DEFAULT_CAPTURE = [
   { marker: '$$', breakable: true },
   { marker: '$', breakable: false },
+  {
+    prefix: '```latex',
+    suffix: '```',
+    strict: true,
+    breakable: true,
+    sanitize: ['*', '//'],
+  },
 ]


### PR DESCRIPTION
Added default latex capture and add markdown to default langs

Multiple line formulas:

\```latex
 \begin{eqnarray*}
  \sum_{i=1}^{n} i^2 &=& \frac{n(n+1)(2n+1)}{6} \\
  \sum_{i=1}^{n} i^3 &=& \left(\frac{n(n+1)}{2}\right)^2 \\
  \sum_{i=1}^{n} i^4 &=& \frac{n(n+1)(2n+1)(3n^2 + 3n - 1)}{30} \\
  \end{eqnarray*}

\```
