### PR TITLE
fix: Build cursor compatible CommonJS extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "Visualization",
     "Snippets"
   ],
-  "main": "./dist/index.mjs",
+  "main": "./dist/index.cjs",
   "icon": "assets/logo.png",
   "engines": {
     "vscode": "^1.84.0"
@@ -222,7 +222,7 @@
   },
   "scripts": {
     "vscode:prepublish": "pnpm run update && pnpm run build",
-    "build": "tsdown src/index.ts --external vscode",
+    "build": "tsdown src/index.ts --external vscode --platform node --format cjs --fixedExtension",
     "dev": "pnpm run build -- --watch",
     "prepare": "pnpm run update",
     "lint": "eslint .",


### PR DESCRIPTION
Cursor has a known compatability gap with ESM-based extensions. Instead build it as a CJS which makes this nice plugin compatible with cursor. With the patch and a locally built extension I can now also use the plugin with cursor!

Feel free to close if you feel that is not within scope of this plugin (or breaks the release in some other way). Thanks for the work.